### PR TITLE
S3 업로드 시 발생하는 로그 해결

### DIFF
--- a/src/main/java/com/bookbook/bookback/controller/TownBookController.java
+++ b/src/main/java/com/bookbook/bookback/controller/TownBookController.java
@@ -43,6 +43,7 @@ public class TownBookController {
 
         List<String> captureImages=new ArrayList<>();
         for(MultipartFile file: files){
+            System.out.println(file);
             String image= fileUploadService.uploadImage(file);
             captureImages.add(image);
         }

--- a/src/main/java/com/bookbook/bookback/service/FileUploadService.java
+++ b/src/main/java/com/bookbook/bookback/service/FileUploadService.java
@@ -1,13 +1,16 @@
 package com.bookbook.bookback.service;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.util.IOUtils;
 import com.bookbook.bookback.utils.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -21,11 +24,23 @@ public class FileUploadService {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentType(file.getContentType());
 
+//        try (InputStream inputStream = file.getInputStream()) {
+//            byte[] bytes = IOUtils.toByteArray(inputStream);
+//            objectMetadata.setContentLength(bytes.length);
+//            s3Service.uploadFile(inputStream, objectMetadata, fileName);
+//        } catch (IOException e) {
+//            throw new IllegalArgumentException(String.format("파일 변환 중 에러가 발생하였습니다 (%s)", file.getOriginalFilename()));
+//        }
         try (InputStream inputStream = file.getInputStream()) {
-            s3Service.uploadFile(inputStream, objectMetadata, fileName);
+            byte[] bytes = IOUtils.toByteArray(inputStream);
+            objectMetadata.setContentLength(bytes.length);
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+            s3Service.uploadFile(byteArrayInputStream , objectMetadata, fileName);
         } catch (IOException e) {
             throw new IllegalArgumentException(String.format("파일 변환 중 에러가 발생하였습니다 (%s)", file.getOriginalFilename()));
         }
+
         return s3Service.getFileUrl(fileName);
     }
 


### PR DESCRIPTION
Sep 30 03:29:32 ip-172-50-10-72 tomcat8: 2019-09-30 12:29:32.717  WARN 27104 --- [io-8443-exec-65] c.amazonaws.services.s3.AmazonS3Client   : No content length specified for stream data.  Stream contents will be buffered in memory and could result in out of memory errors.